### PR TITLE
Docs: Registra a Daily Scrum de 17/09/2025 #4

### DIFF
--- a/docs/dailys/daily1709.md
+++ b/docs/dailys/daily1709.md
@@ -1,0 +1,31 @@
+# Daily Scrum - 17/09/2025
+
+**Presentes:** Guilherme, Kaio, Samuel
+
+---
+
+### Resumo por Participante
+
+#### Guilherme
+* **Ontem:** Entrei em contato com colegas que trabalham em empresas de desenvolvimento de software, a fim de coletar informações sobre como um software é custeado.
+* **Hoje:** Vou entrar em contato com alguém que conheça pessoas envolvidas diretamente na elaboração dos projetos de desenvolvimento de softwares da empresa. Após coletar uma quantidade satisfatória de informações vou elaborar um documento com elas para que o mediador da mesa redonda possa criar as perguntas.
+* **Impedimentos:** É difícil obter esse tipo de informação diretamente com a empresa ou responsável direto.
+
+#### Kaio
+* **Ontem:** Pesquisei e selecionei alguns artigos que abordavam o custeamento de software.
+* **Hoje:** Vou esperar a conclusão dos documentos sobre o custeamento de softwares para fazer o documento com as perguntas para o mediador da mesa redonda.
+* **Impedimentos:** Não há empecilhos.
+
+#### Samuel
+* **Ontem:** Pesquisei ligeiramente alguns artigos que abordassem o custeamento de software afim de explorar o assunto e me preparar para a seleção dos artigos definitivos.
+* **Hoje:** Vou selecionar os artigos que usei para fazer a documentação. Após consolidar o conteúdo vou criar o documento para que seja usado pelo mediador para criar as perguntas que serão feitas na mesa redonda.
+* **Impedimentos:** Não há empecilhos.
+
+---
+
+### Impedimentos Consolidados
+* Não há impediemtos.
+
+### Decisões / Próximos Passos
+* Decidimos que Kaio será o mediador;
+* Todos os integrantes do projeto devem completar sua issue adicionando seu documento ao repositório.


### PR DESCRIPTION
## Este PR adiciona o registro da Daily Scrum realizada no dia 17 de setembro de 2025, conforme solicitado na issue #4 

### O que foi feito?

- Adicionado o arquivo `daily1709.md` no diretório `docs/dailys/`.
- O arquivo foi preenchido com o resumo da reunião, incluindo o status reportado por cada membro da equipe e os impedimentos identificados.