### PR TITLE
docs: Registra a Daily Scrum de 19/09/2025 #8

### DIFF
--- a/docs/dailys/daily1909.md
+++ b/docs/dailys/daily1909.md
@@ -1,0 +1,31 @@
+# Daily Scrum - 19/09/2025
+
+**Presentes:** Guilherme, Kaio, Samuel
+
+---
+
+### Resumo por Participante
+
+#### Guilherme 
+* **Ontem:** Entrevistei pessoas que tinham experiencia com custeamento de software e obtive informações suficientes.
+* **Hoje:** Com as informações que adiquiri com as entrevistas vou fazer o documento referente a custo de software pelo ponto de visão da empresa, que será usado para Kaio elaborar as perguntas para a mesa redonda. Também pretendo deixar o template do documento de User Stories (US) pronto e designiar as US para cada membro da equipe.
+* **Impedimentos:** Dificuldade em achar pessoas que possuam experiencia prática em custear softwares.
+
+#### Kaio
+* **Ontem:** Pesquisei sobre como funciona uma mesa redonda e como ser mediador
+* **Hoje:** Estudar os documentos de Guilherme e Samuel para conduzir a mesa redonda
+* **Impedimentos:** Nenhum
+
+#### Samuel 
+* **Ontem:** Fiz do documento contendo a pesquisa e os artigos utilizados como referência
+* **Hoje:** Adicionar data de acesso dos artigos na seção de referências
+* **Impedimentos:** Poucos ao tentar procurar os artigos para a pesquisa
+
+
+---
+
+### Impedimentos Consolidados
+* Sem impedimentos.
+
+### Decisões / Próximos Passos
+* Adiar um pouco a entrega final do documento de história de usuários a fim de dar mais tempo a equipe para se preparar para uma prova difícil.


### PR DESCRIPTION
## Este PR adiciona o registro da Daily Scrum realizada no dia 19 de setembro de 2025, conforme solicitado na issue #8 

### O que foi feito?

- Adicionado o arquivo `daily1909.md` no diretório `docs/dailys/`.
- O arquivo foi preenchido com o resumo da reunião, incluindo o status reportado por cada membro da equipe e os impedimentos identificados.